### PR TITLE
[scripts] tfrnnlm rescoring binary reads unk.probs file directly

### DIFF
--- a/egs/wsj/s5/steps/lmrescore_rnnlm_lat.sh
+++ b/egs/wsj/s5/steps/lmrescore_rnnlm_lat.sh
@@ -58,7 +58,7 @@ fi
 
 if [ "$rnnlm_ver" == "tensorflow" ]; then
   rescoring_binary="lattice-lmrescore-tf-rnnlm"
-  first_arg="$first_arg $rnnlm_dir/wordlist.rnn.final"
+  first_arg="$rnnlm_dir/unk.probs $rnnlm_dir/wordlist.rnn.final"
 fi
 
 oldlm=$oldlang/G.fst


### PR DESCRIPTION
SetUnkPenalties function in tfrnnlm/tensorflow-rnnlm.cc is using ifstream for reading file